### PR TITLE
fix: emit number as number instead of string

### DIFF
--- a/tap_oracle/sync_strategies/common.py
+++ b/tap_oracle/sync_strategies/common.py
@@ -51,6 +51,12 @@ def row_to_singer_message(stream, row, version, columns, time_extracted):
         elif 'integer' in property_type or property_type == 'integer':
             integer_representation = int(elem)
             row_to_persist += (integer_representation,)
+        elif 'number' in property_type or property_type == 'number':
+            str_representation = str(elem)
+            if '.' in str_representation:
+                row_to_persist += (float(elem),)
+            else:
+                row_to_persist += (int(elem),)
         elif description == 'blob':
             base64encode = base64.b64encode(elem)
             row_to_persist += (base64encode,)

--- a/tests/test_full_table.py
+++ b/tests/test_full_table.py
@@ -199,31 +199,31 @@ class FullTable(unittest.TestCase):
 
             expected_rec_1 = {'ID'                  : 1,
                               'none_column'         : None,
-                              'size_number'         : decimal.Decimal('0.000001'),
-                              'size_number_*'       : decimal.Decimal('100.12345'),
+                              'size_number'         : 1E-6,
+                              'size_number_*'       : 100.12345,
                               'size_number_4'       : 100,
                               'size_number_4_0'     : 100,
                               'size_number_*_0'     : 2 ** 128,
-                              'size_number_*_38'    : decimal.Decimal('0.000001'),
+                              'size_number_*_38'    : 1e-06,
                               'size_number_10_-1'   : 310,
                               'size_number_integer' : 400,
                               'size_number_int'     : 500,
                               'size_number_smallint': 50000,
 
-                              'our_number_10_2'     : decimal.Decimal('100.11'),
-                              'our_number_38_4'     : decimal.Decimal('99999999999999999.9999'),
+                              'our_number_10_2'     : 100.11,
+                              'our_number_38_4'     : 99999999999999999.9999,
 
-                              'our_double_precision': decimal.Decimal('1234567.8901234567890123456789012345679'),
-                              'our_float'           : decimal.Decimal('1234567.8901234567890123456789012345679'),
-                              'our_real'            : decimal.Decimal('1234567.890123456789'),
+                              'our_double_precision': 1234567.890123456789012345679,
+                              'our_float'           : 1234567.8901234567,
+                              'our_real'            : 1234567.890123456789,
 
 
 
-                              'our_binary_float'    : decimal.Decimal('1234567.88'),
-                              'our_binary_double'   : decimal.Decimal('1234567.8901229999'), # 1234567.875
+                              'our_binary_double'   : 1234567.8901229999, # 1234567.875
+                              'our_binary_float'    : 1234567.88,
                               'our_nan'             : None,
-                              'our_+_infinity'      : decimal.Decimal('1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
-                              'our_-_infinity'      : decimal.Decimal('-1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+                              'our_+_infinity'      : 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+                              'our_-_infinity'      : -1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
 
                               'our_date'            : '1996-06-06T00:00:00.00+00:00',
                               'our_ts'              : '1997-02-02T02:02:02.722184+00:00',
@@ -249,9 +249,9 @@ class FullTable(unittest.TestCase):
             expected_rec_2 = expected_rec_1
             expected_rec_2.update({
                 'ID': decimal.Decimal(2),
-                'size_number_4_0' : decimal.Decimal('101'),
-                'our_number_10_2' : decimal.Decimal('101.11') + 1,
-                'our_double_precision' : our_double_precision + 1,
+                'size_number_4_0' : 101,
+                'our_number_10_2' : 101.11 + 1,
+                'our_double_precision' : 1234568.8901234567,#decimal.Decimal(our_double_precision) + 1,
                 'our_date' : '1996-06-07T00:00:00.00+00:00',
                 'NAME_NCHAR' :  'name-nchar II                                                                                                              '})
             #self.assertTrue(math.isnan(CAUGHT_MESSAGES[4].record.get('our_nan')))


### PR DESCRIPTION
## Problem

Certain targets such as postgres type check input against the schema.

## Proposed changes

If the format is a number, emit it as integer or float.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Unit tests for changes (not needed for documentation changes)
- [X] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [X] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions